### PR TITLE
Fix JSON parse error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,4 +20,5 @@
             "name": "Luke Cavanagh",
             "homepage": "https://github.com/lukecav"
         }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "readme": "README.md",
     "author": [
         {
-            "name": "Luke Cavanagh
+            "name": "Luke Cavanagh",
             "homepage": "https://github.com/lukecav"
         }
 }


### PR DESCRIPTION
Fixes the following error when using `composer require`.

```
Skipped branch main, "ce943290674cafe33c74b3d10e7fb09593a54495:composer.json" does not contain valid JSON
Parse error on line 20:
...            "name": "Luke Cavanagh
----------------------^
Invalid string, it appears you forgot to terminate a string, or attempted to write a multiline string which is invalid
```